### PR TITLE
fix: update mustache and remove require

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "umd"
   ],
   "dependencies": {
-    "mustache": "^2.2.1"
+    "mustache": "^4.2.0"
   },
   "peerDependencies": {
     "react": "^15.0.2"
   },
   "devDependencies": {
-    "nwb": "0.9.x",
+    "nwb": "^0.25.2",
     "react": "^15.0.2"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,8 @@
-import React, { Component } from 'react';
-const Mustache = require('mustache');
-
-export default class ReactMustache extends React.Component {
-
-  compileTemplate(template, data) {
-    // lazy template compiling
-    return Mustache.render(template,data);
-  }
-
-  render() {
-    const { template, data, Component } = this.props;
-
-    if (!template) return false
-
-    const __html = this.compileTemplate(template, data);
-
-    return (
-      <Component dangerouslySetInnerHTML={{__html}}/>
-    )
-  }
-}
-
-ReactMustache.defaultProps = {
-  data: {},
-  Component: 'div'
-}
+import Mustache from "mustache";
+import React from "react";
+export const ReactMustache = ({ template, data = {}, Component = "div" }) =>
+  template ? (
+    <Component
+      dangerouslySetInnerHTML={{ __html: Mustache.render(template, data) }}
+    />
+  ) : null;


### PR DESCRIPTION
Hello, 

I'm using ReactMustache on a project builded with Vite, but the build fails due to the `const Mustache = require('mustache');`

I propose this PR with:
* updated Mustache dep
* `require` replaced by `import`
* JSX component syntax